### PR TITLE
Fix SCSS import

### DIFF
--- a/src/styles/homePage.scss
+++ b/src/styles/homePage.scss
@@ -1,4 +1,4 @@
-@import '_variables'
+@import '_variables';
 
 // Site Header
 .site-header {


### PR DESCRIPTION
## Summary
- fix missing semicolon in homePage.scss imports

## Testing
- `npx eslint . --ext js,jsx,ts,tsx --fix` *(fails: Cannot find module 'eslint' due to env)*


------
https://chatgpt.com/codex/tasks/task_e_684a4230101083279a4a467ebae895c2